### PR TITLE
backward compatibility

### DIFF
--- a/collective/recipe/pip/__init__.py
+++ b/collective/recipe/pip/__init__.py
@@ -4,7 +4,11 @@ import itertools
 import os
 
 from pip import req
-from pip.download import PipSession
+try:
+    from pip.download import PipSession
+    has_pipsession = True
+except ImportError:
+    has_pipsession = False
 
 
 old_parse_requirements = req.parse_requirements
@@ -57,7 +61,7 @@ class Recipe(object):
             if requirement.editable:
                 urls.append(requirement.url)
             elif requirement.url:
-                if not '#egg=' in requirement.url:
+                if '#egg=' not in requirement.url:
                     urls.append('{0}#egg={1}{2}'.format(requirement.url, requirement.name, specs))
                 else:
                     urls.append(requirement.url)
@@ -80,7 +84,11 @@ class Recipe(object):
             if os.path.exists(file_dir):
                 os.chdir(file_dir)
             try:
-                return req.parse_requirements(file, options=self, finder=self, session=PipSession())
+                if has_pipsession:
+                    return req.parse_requirements(file, options=self, finder=self,
+                                                  session=PipSession())
+                else:
+                    return req.parse_requirements(file, options=self, finder=self)
             finally:
                 os.chdir(self.buildout['buildout']['directory'])
         except SystemExit:


### PR DESCRIPTION
Using latest recipe 0.3.1 with pip 1.5.6 leads to an import error:

```
An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 1946, in main
    getattr(buildout, command)(args)
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 510, in install
    [self[part]['recipe'] for part in install_parts]
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 1098, in __getitem__
    options._initialize()
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 1202, in _initialize
    self.initialize()
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 1208, in initialize
    recipe_class = _install_and_load(reqs, 'zc.buildout', entry, buildout)
  File "/home/ccomb/.buildout/eggs/zc.buildout-2.3.1-py2.7.egg/zc/buildout/buildout.py", line 1167, in _install_and_load
    req.project_name, group, entry)
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2682, in load_entry_point
    return ep.load()
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2355, in load
    return self.resolve()
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2361, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/home/ccomb/.buildout/eggs/collective.recipe.pip-0.3.1-py2.7.egg/collective/recipe/pip/__init__.py", line 7, in <module>
    from pip.download import PipSession
ImportError: cannot import name PipSession
```

I've added a fallback to not using pipsession