### PR TITLE
Convert version to string

### DIFF
--- a/collective/recipe/pip/__init__.py
+++ b/collective/recipe/pip/__init__.py
@@ -77,7 +77,7 @@ class Recipe(object):
         if versions_part_name:
             versions_part = self.buildout[versions_part_name]
             for egg, version in versions:
-                versions_part.setdefault(egg, version)
+                versions_part.setdefault(egg, str(version))
 
     def parse_files(self, files):
         """Parse files."""


### PR DESCRIPTION
When I tried to use cr.pip on my buildout I get 

```
TypeError: ('Option values must be strings', u'1.2.4')
```

This pr makes resolves the issue by converting the version to string before passing it to buildout.
