### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ and buildout for same project independently
 
 .. image:: https://travis-ci.org/collective/collective.recipe.pip.png
    :target: https://travis-ci.org/collective/collective.recipe.pip
-.. image:: https://pypip.in/v/collective.recipe.pip/badge.png
+.. image:: https://img.shields.io/pypi/v/collective.recipe.pip.svg
    :target: https://crate.io/packages/collective.recipe.pip/
 .. image:: https://coveralls.io/repos/collective/collective.recipe.pip/badge.png?branch=master
    :target: https://coveralls.io/r/collective/collective.recipe.pip


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20collective-recipe-pip))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `collective-recipe-pip`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.